### PR TITLE
jQuery form validation

### DIFF
--- a/OSS/Smarty/functions/function.addJSValidator.php
+++ b/OSS/Smarty/functions/function.addJSValidator.php
@@ -291,6 +291,8 @@
                                 wraper.addClass( 'error' );
                                 if( wraper.parent().hasClass( 'tab-pane' ) )
                                     $( 'a[href|=\"#' + wraper.parent().attr( 'id' ) + '\"]' ).addClass( 'text-error' );
+                                else if( wraper.parent().parent().hasClass( 'row' ) && wraper.parent().parent().parent().hasClass( 'tab-pane' ) )
+                                    $( 'a[href|=\"#' + wraper.parent().parent().parent().attr( 'id' ) + '\"]' ).addClass( 'text-error' );
                              }
         });
     });


### PR DESCRIPTION
Adding error class on closest element with control-group class, instead of just putting it on div with index "div-form-{field_id}"  solves issues with Twitter_Form generated elements. 

And also it will add indicator on tab ( if form have tabs ) in which tab error occurred.
