### PR TITLE
Honor HTTP_X_FORWARDED_PROTO server variable

### DIFF
--- a/src/OSS/Utils.php
+++ b/src/OSS/Utils.php
@@ -240,12 +240,18 @@ class OSS_Utils
         
         if( strpos( $url, 'http' ) !== 0 )
         {
-            $tmp = 'http';
+            $protocol = 'http';
 
             if( isset( $_SERVER['HTTPS'] ) && ( $_SERVER['HTTPS'] == 'on' ) )
-                $tmp .= 's';
+            {
+                $protocol = 'https';
+            }
+            elseif( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) )
+            {
+                $protocol = $_SERVER['HTTP_X_FORWARDED_PROTO'];
+            }
 
-            $url = "{$tmp}://{$url}";
+            $url = "{$protocol}://{$url}";
         }
 
         if( $module )


### PR DESCRIPTION
Nginx could define HTTP_X_FORWARDED_PROTO as 'https' if a vhost in fine serves content over https.

In such case, {{genUrl}} printed http:// and not https:// as protocol. We now honor this HTTP_X_FORWARDED_PROTO variable.